### PR TITLE
chore: specify node and npm versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,9 @@
   "main": "index.js",
   "repository": "https://github.com/Chaosthebot/Chaos-Core.git",
   "author": "ChaosBot contributors",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": { 
+    "node": "~8.1.3",
+    "npm": "~5.0.3"
+  }
 }


### PR DESCRIPTION
We should be as expressive as possible when creating our `package.json` for the sake of everyone committing to the core functionality.

I propose we use `node 8` and `npm 5` so we can take advantage of newer, faster node runtimes and the `package-lock.json`. I've been dying to try this out over `yarn`.